### PR TITLE
Update Like button CSS selector

### DIFF
--- a/main.js
+++ b/main.js
@@ -174,7 +174,7 @@ window.addEventListener('load', function() {
     } else if (event.keyCode == letter_w){
       window.location = '/playlist?list=WL';
     } else if (event.keyCode == letter_h){
-      let likeButton = document.querySelector('ytd-video-primary-info-renderer ytd-toggle-button-renderer:first-child');
+      let likeButton = document.querySelector('#segmented-like-button yt-button-shape button');
       likeButton && likeButton.click();
     } else if (event.keyCode == backspace){
       window.history.back();


### PR DESCRIPTION
## What does this PR do?
As of October 2022, pressing 'h' doesn't Like a video anymore.
This PR updates DOM selector to make the clicking Like button feature works again.

## Checklist before merging
- [x] Test on Chromium (MS Edge)